### PR TITLE
Feature/add plugin publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
+plugins {
+    id "com.gradle.plugin-publish" version "0.9.10"
+}
 
 apply plugin: 'groovy'
 apply plugin: 'java-gradle-plugin'
+apply plugin: "com.gradle.plugin-publish"
 
 group = 'com.github.jengelman.gradle.plugins'
 version = '0.4.0-SNAPSHOT'
@@ -9,9 +13,6 @@ ext.isSnapshot = version.endsWith("SNAPSHOT")
 
 repositories {
     jcenter()
-    maven {
-        url 'http://dl.bintray.com/johnrengelman/gradle-plugins'
-    }
 }
 
 dependencies {
@@ -24,7 +25,7 @@ dependencies {
 
     testCompile 'org.apache.commons:commons-io:1.3.2'
 
-    testCompile 'junit:junit:4.11'
+    testCompile 'junit:junit:4.12'
 
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
@@ -32,3 +33,26 @@ dependencies {
 
 targetCompatibility = 1.6
 sourceCompatibility = 1.6
+
+gradlePlugin {
+    plugins {
+        gradleProcessesPlugin {
+            id = 'com.github.johnrengelman.processes'
+            implementationClass = 'com.github.jengelman.gradle.plugins.processes.ProcessesPlugin'
+        }
+    }
+}
+
+pluginBundle {
+    vcsUrl = 'https://github.com/johnrengelman/gradle-processes'
+    description = 'Create and manage forked processes directly from gradle.'
+    tags = ['processes', 'fork']
+
+    plugins {
+        gradleProcessesPlugin {
+            displayName = "Create and manage forked processes directly from gradle."
+            id = 'com.github.johnrengelman.processes'
+            website = "https://github.com/johnrengelman/gradle-processes"
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ dependencies {
 
     testCompile 'org.apache.commons:commons-io:1.3.2'
 
-    testCompile 'junit:junit:4.12'
-
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/src/main/resources/META-INF/gradle-plugins/com.github.johnrengelman.processes.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.github.johnrengelman.processes.properties
@@ -1,1 +1,0 @@
-implementation-class=com.github.jengelman.gradle.plugins.processes.ProcessesPlugin


### PR DESCRIPTION
Added the gradle publishing plugin so this can easily be published to https://plugins.gradle.org.
Tests still run. Inside IDEA you have to `Build Tools > Gradle > Runner > Run Tests > Using gradle runner` since otherwise the classpath including generated main resources is not properly set up. 